### PR TITLE
Improve subscription grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@
 Esta herramienta permite mostrar las suscripciones reales asociadas a una cuenta de correo electrónico.
 Utiliza el protocolo IMAP para inspeccionar los mensajes de la bandeja de entrada y extraer la información de las listas de distribución.
 
+Se inspeccionan los mensajes buscando las cabeceras reales `List-Id` y
+`List-Unsubscribe`. Las suscripciones se agrupan por el valor de `List-Id`, de
+modo que cada entrada refleja una lista concreta junto con los remitentes y los
+métodos de desuscripción asociados.
+
 ## Uso rápido
 
 ```bash
 python3 suscripciones.py --servidor imap.ejemplo.com --correo usuario@ejemplo.com
 ```
-El programa solicitará la contraseña de la cuenta para iniciar sesión y, a continuación, listará las suscripciones detectadas.
+El programa solicitará la contraseña de la cuenta para iniciar sesión y, a continuación,
+listará las suscripciones detectadas. Opcionalmente se puede indicar el buzón a revisar
+mediante `--mailbox`.
 
 ## Requisitos
 

--- a/suscripciones.py
+++ b/suscripciones.py
@@ -7,7 +7,8 @@ import imaplib
 import email
 from collections import defaultdict
 from email.header import decode_header
-from typing import Dict, Set
+from typing import DefaultDict, Dict, Set
+import sys
 
 
 def conectar(imap_server: str, email_user: str, password: str) -> imaplib.IMAP4_SSL:
@@ -17,27 +18,30 @@ def conectar(imap_server: str, email_user: str, password: str) -> imaplib.IMAP4_
     return imap
 
 
-def obtener_suscripciones(imap: imaplib.IMAP4_SSL, mailbox: str = "INBOX") -> Dict[str, Set[str]]:
-    """Devuelve un diccionario de remitentes y sus cabeceras de desuscripción."""
-    suscripciones: Dict[str, Set[str]] = defaultdict(set)
+def obtener_suscripciones(imap: imaplib.IMAP4_SSL, mailbox: str = "INBOX") -> Dict[str, Dict[str, Set[str]]]:
+    """Devuelve las cabeceras de listas de correo agrupadas por ``List-Id``."""
+    suscripciones: DefaultDict[str, Dict[str, Set[str]]] = defaultdict(lambda: {"remitentes": set(), "unsub": set()})
+
     imap.select(mailbox)
     status, data = imap.search(None, "ALL")
-    if status != "OK":
+    if status != "OK" or not data or not data[0]:
         return suscripciones
 
     for num in data[0].split():
-        status, msg_data = imap.fetch(num, '(RFC822.HEADER)')
+        status, msg_data = imap.fetch(num, '(BODY.PEEK[HEADER])')
         if status != 'OK' or not msg_data:
             continue
         msg = email.message_from_bytes(msg_data[0][1])
-        list_unsub = msg.get('List-Unsubscribe')
         list_id = msg.get('List-Id')
-        if list_unsub or list_id:
-            from_addr = email.utils.parseaddr(msg.get('From'))[1]
-            if list_unsub:
-                suscripciones[from_addr].add(list_unsub)
-            if list_id:
-                suscripciones[from_addr].add(list_id)
+        list_unsub = msg.get('List-Unsubscribe')
+        if not list_id and not list_unsub:
+            continue
+        key = list_id if list_id else email.utils.parseaddr(msg.get('From'))[1]
+        remitente = email.utils.parseaddr(msg.get('From'))[1]
+        suscripciones[key]["remitentes"].add(remitente)
+        if list_unsub:
+            suscripciones[key]["unsub"].add(list_unsub)
+
     return suscripciones
 
 
@@ -54,23 +58,33 @@ def decodificar(texto: str) -> str:
     return ''.join(resultado)
 
 
-def mostrar_suscripciones(suscripciones: Dict[str, Set[str]]):
+def mostrar_suscripciones(suscripciones: Dict[str, Dict[str, Set[str]]]):
     if not suscripciones:
         print("No se encontraron suscripciones")
         return
+
     print("Suscripciones encontradas:")
-    for remitente, datos in suscripciones.items():
-        print(f"- {remitente}")
-        for d in datos:
-            print(f"    {decodificar(d)}")
+    for list_id, datos in suscripciones.items():
+        print(f"- {decodificar(list_id)}")
+        for remitente in sorted(datos["remitentes"]):
+            print(f"    Remitente: {remitente}")
+        for unsub in sorted(datos["unsub"]):
+            print(f"    Desuscribir: {decodificar(unsub)}")
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Muestra las suscripciones asociadas a una cuenta de correo")
+    parser = argparse.ArgumentParser(
+        description="Muestra las suscripciones asociadas a una cuenta de correo"
+    )
     parser.add_argument("--servidor", required=True, help="Servidor IMAP, por ejemplo: imap.gmail.com")
     parser.add_argument("--correo", required=True, help="Dirección de correo electrónico")
     parser.add_argument("--mailbox", default="INBOX", help="Buzón a inspeccionar")
     args = parser.parse_args()
+
+    if hasattr(sys.stdout, "reconfigure"):
+        # Asegura que la salida utilice UTF-8 para evitar errores con caracteres
+        # no ASCII en sistemas cuyo locale no esté configurado.
+        sys.stdout.reconfigure(encoding="utf-8")
 
     password = getpass.getpass(prompt=f"Contraseña para {args.correo}: ")
     try:


### PR DESCRIPTION
## Summary
- aggregate subscriptions by `List-Id` value
- include senders and unsubscribe headers for each list
- clarify README to explain grouping
- ensure stdout uses UTF-8 to avoid ASCII encoding errors

## Testing
- `python3 -m py_compile suscripciones.py`


------
https://chatgpt.com/codex/tasks/task_e_6843089b6178832c8f9f2fa2a55ccf48